### PR TITLE
cmake: use hyphenated export set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ endif()
 set(QUANT_PRICER_HAS_OPENMP ${HAS_OPENMP})
 
 install(TARGETS quant_pricer quant_cli
-  EXPORT quant_pricerTargets
+  EXPORT quant-pricer-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -168,7 +168,7 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/external/pcg/include)
           PATTERN ".DS_Store" EXCLUDE)
 endif()
 
-install(EXPORT quant_pricerTargets
+install(EXPORT quant-pricer-targets
   FILE quant-pricer-targets.cmake
   NAMESPACE quant_pricer::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/quant-pricer


### PR DESCRIPTION
## Summary
- rename the installed export set to `quant-pricer-targets` so that it matches the package configuration include

## Testing
- cmake -S . -B build && cmake --build build --config Release
- cmake --install build --prefix install
- ./scripts/demo.sh
- ctest --test-dir build --output-on-failure
- ./build/bench_mc --benchmark_min_time=0.2
- ./build/bench_pde --benchmark_min_time=0.2


------
https://chatgpt.com/codex/tasks/task_e_68e18cc47ebc8324a3567c6e769f8e51